### PR TITLE
Añadir parámetro #INSTRUM a las canciones

### DIFF
--- a/src/base/UAvatars.pas
+++ b/src/base/UAvatars.pas
@@ -1,8 +1,8 @@
 {*
     UltraStar WorldParty - Karaoke Game
-
-	UltraStar WorldParty is the legal property of its developers,
-	whose names	are too numerous to list here. Please refer to the
+	
+	UltraStar WorldParty is the legal property of its developers, 
+	whose names	are too numerous to list here. Please refer to the 
 	COPYRIGHT file distributed with this source distribution.
 
     This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program. Check "LICENSE" file. If not, see
+    along with this program. Check "LICENSE" file. If not, see 
 	<http://www.gnu.org/licenses/>.
  *}
 
@@ -24,148 +24,469 @@ unit UAvatars;
 
 interface
 
-{$MODE OBJFPC}
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
 
 {$I switches.inc}
 
 uses
+  sdl2,
+  SQLite3,
+  SQLiteTable3,
   SysUtils,
   Classes,
+  UImage,
   UIni,
-  UPath,
-  UTexture;
+  UTexture,
+  UPath;
 
 type
-  TAvatar = class
-    Id: integer;
-    MD5: string;
-    Texture: TTexture;
+  ECoverDBException = class(Exception)
   end;
 
-  TAvatarPlayerTextures = array[1..UIni.IMaxPlayerCount] of TTexture;
-
-  TAvatarList = class
+  TAvatar = class
     private
-      Avatars: TFPList;
-      AvatarPlayerTextures: TAvatarPlayerTextures;
-      AvatarPlayerNoTextures: TAvatarPlayerTextures;
+      ID: int64;
+      Filename: IPath;
+    public
+      constructor Create(ID: int64; Filename: IPath);
+      function GetPreviewTexture(): TTexture;
+      function GetTexture(): TTexture;
+  end;
+
+  TAvatarThumbnailInfo = record
+    AvatarWidth: integer;         // Original width of avatar
+    AvatarHeight: integer;        // Original height of avatar
+    PixelFormat: TImagePixelFmt; // Pixel-format of avatar thumbnail
+  end;
+
+  TAvatarDatabase = class
+    private
+      DB: TSQLiteDatabase;
+
+      procedure InitAvatarDatabase();
+      function CreateAvatarThumbnail(const Filename: IPath; var Info: TAvatarThumbnailInfo): PSDL_Surface;
+      function LoadAvatar(AvatarID: int64): TTexture;
+      procedure DeleteAvatar(AvatarID: int64);
+      function FindAvatarIntern(const Filename: IPath): int64;
+      procedure Open();
+      function GetVersion(): integer;
+      procedure SetVersion(Version: integer);
     public
       constructor Create();
-      function GetAvatars(): TFPList;
-      function GetPlayers(): TAvatarPlayerTextures;
-      function GetPlayersNo(): TAvatarPlayerTextures;
-      procedure LoadConfig(Party: boolean = false);
+      destructor Destroy; override;
+      function AddAvatar(const Filename: IPath): TAvatar;
+      function FindAvatar(const Filename: IPath): TAvatar;
+      function AvatarExists(const Filename: IPath): boolean;
+      function GetMaxAvatarSize(): integer;
+      procedure SetMaxAvatarSize(Size: integer);
+      procedure LoadAvatars();
   end;
 
-function GetAvatarsList(): TAvatarList;
-procedure SetAvatarsList();
+  TBlobWrapper = class(TCustomMemoryStream)
+     function Write(const Buffer; Count: Integer): Integer; override;
+  end;
+
+var
+  Avatars: TAvatarDatabase;
+  AvatarsList: array of IPath;
+  NoAvatarTexture: array[1..UIni.IMaxPlayerCount] of TTexture;
+  AvatarPlayerTextures: array[1..UIni.IMaxPlayerCount] of TTexture;
 
 implementation
 
 uses
-  UCommon,
-  UFilesystem,
-  UGraphic,
+  UMain,
+  ULog,
   UPathUtils,
-  UScreenScore,
-  UScreenSingController,
-  USkins,
-  UThemes,
-  md5;
+  UPlatform,
+  UFilesystem,
+  Math,
+  DateUtils;
 
-var
-  AvatarsList: TAvatarList;
+const
+  AVATARDB_FILENAME: UTF8String = 'avatar.db';
+  AVATARDB_VERSION = 01; // 0.1
+  AVATAR_TBL = 'Avatar';
+  AVATAR_THUMBNAIL_TBL = 'AvatarThumbnail';
+  AVATAR_IDX = 'Avatar_Filename_IDX';
 
-function GetAvatarsList(): TAvatarList;
+// Note: DateUtils.DateTimeToUnix() will throw an exception in FPC
+function DateTimeToUnixTime(time: TDateTime): int64;
 begin
-  Result := AvatarsList;
+  Result := Round((time - UnixDateDelta) * SecsPerDay);
 end;
 
-procedure SetAvatarsList();
+// Note: DateUtils.UnixToDateTime() will throw an exception in FPC
+function UnixTimeToDateTime(timestamp: int64): TDateTime;
 begin
-  AvatarsList := UAvatars.TAvatarList.Create();
+  Result := timestamp / SecsPerDay + UnixDateDelta;
 end;
 
-constructor TAvatarList.Create();
+
+{ TBlobWrapper }
+
+function TBlobWrapper.Write(const Buffer; Count: Integer): Integer;
+begin
+  SetPointer(Pointer(Buffer), Count);
+  Result := Count;
+end;
+
+
+{ TCover }
+
+constructor TAvatar.Create(ID: int64; Filename: IPath);
+begin
+  Self.ID := ID;
+  Self.Filename := Filename;
+end;
+
+function TAvatar.GetPreviewTexture(): TTexture;
+begin
+  Result := Avatars.LoadAvatar(ID);
+end;
+
+function TAvatar.GetTexture(): TTexture;
+begin
+  Result := Texture.LoadTexture(Filename);
+end;
+
+
+{ TCoverDatabase }
+
+constructor TAvatarDatabase.Create();
+begin
+  inherited;
+
+  Open();
+  LoadAvatars();
+  InitAvatarDatabase();
+end;
+
+destructor TAvatarDatabase.Destroy;
+begin
+  DB.Free;
+  inherited;
+end;
+
+function TAvatarDatabase.GetVersion(): integer;
+begin
+  Result := DB.GetTableValue('PRAGMA user_version');
+end;
+
+procedure TAvatarDatabase.SetVersion(Version: integer);
+begin
+  DB.ExecSQL(Format('PRAGMA user_version = %d', [Version]));
+end;
+
+function TAvatarDatabase.GetMaxAvatarSize(): integer;
+begin
+  Result := ITextureSizeVals[Ini.TextureSize];
+end;
+
+procedure TAvatarDatabase.SetMaxAvatarSize(Size: integer);
 var
   I: integer;
-  Iterator: IFileIterator;
-  Extension: string;
-  FileInfo: TFileInfo;
-  Path: IPath;
-  Avatar: TAvatar;
 begin
-  inherited Create();
-  Self.Avatars := TFPList.Create();
-  I := 1;
-  for Extension in ['jpg', 'png'] do
+  // search for first valid avatar-size > Size
+  for I := 0 to Length(ITextureSizeVals)-1 do
   begin
-    Iterator := UFilesystem.FileSystem.FileFind(UPathUtils.AvatarsPath.Append('*.' + Extension), 0);
-    while Iterator.HasNext() do
+    if (Size <= ITextureSizeVals[I]) then
     begin
-      FileInfo := Iterator.Next();
-      Avatar := TAvatar.Create();
-      Avatar.Id := I;
-      Path := UPathUtils.AvatarsPath.Append(FileInfo.Name);
-      Avatar.MD5 := MD5Print(MD5File(Path.ToNative()));
-      Avatar.Texture := UTexture.Texture.LoadTexture(Path);
-      Self.Avatars.Add(Avatar);
-      Inc(I);
+      Ini.TextureSize := I;
+      Exit;
     end;
   end;
-  for I := 1 to UIni.IMaxPlayerCount do
-    Self.AvatarPlayerNoTextures[I] := UTexture.Texture.LoadTexture(USkins.Skin.GetTextureFileName('NoAvatar_P' + IntToStr(I)), TEXTURE_TYPE_TRANSPARENT, $FFFFFF);
 
-  Self.LoadConfig();
+  // fall-back to highest size
+  Ini.TextureSize := High(ITextureSizeVals);
 end;
 
-function TAvatarList.GetAvatars(): TFPList;
-begin
-  Result := Self.Avatars;
-end;
-
-function TAvatarList.GetPlayers(): TAvatarPlayerTextures;
-begin
-  Result := Self.AvatarPlayerTextures;
-end;
-
-function TAvatarList.GetPlayersNo(): TAvatarPlayerTextures;
-begin
-  Result := Self.AvatarPlayerNoTextures;
-end;
-
-procedure TAvatarList.LoadConfig(Party: boolean = false);
+procedure TAvatarDatabase.Open();
 var
-  Avatar: TAvatar;
-  Col: TRGB;
-  I, J: Integer;
+  Version: integer;
+  Filename: IPath;
 begin
-  if not Party then
-    for I := 0 to Self.Avatars.Count - 1 do
-    begin
-      Avatar := TAvatar(Self.Avatars[I]);
-      J := UCommon.GetArrayIndex(UIni.Ini.PlayerAvatar, Avatar.MD5);
-      if J <> -1 then
-        Self.AvatarPlayerTextures[J + 1] := Avatar.Texture;
-    end;
+  Filename := Platform.GetGameUserPath().Append(AVATARDB_FILENAME);
 
-  for I := 1 to High(Self.AvatarPlayerTextures) do
-    if Party or (Self.AvatarPlayerTextures[I].TexNum = 0) then
-    begin
-      Self.AvatarPlayerTextures[I] := Self.AvatarPlayerNoTextures[I];
-      Col := UThemes.GetPlayerColor(UIni.Ini.PlayerColor[I]);
-      Self.AvatarPlayerTextures[I].ColR := Col.R;
-      Self.AvatarPlayerTextures[I].ColG := Col.G;
-      Self.AvatarPlayerTextures[I].ColB := Col.B;
-    end;
+  DB := TSQLiteDatabase.Create(Filename.ToUTF8());
+  Version := GetVersion();
 
-  UThemes.LoadPlayersColors();
-  UThemes.Theme.ThemeScoreLoad();
-  if Assigned(UGraphic.ScreenScore) then
+  // check version, if version is too old/new, delete database file
+  if ((Version <> 0) and (Version <> AVATARDB_VERSION)) then
   begin
-    UGraphic.ScreenScore := UScreenScore.TScreenScore.Create();
-    UGraphic.ScreenSing := UScreenSingController.TScreenSingController.Create();
+    Log.LogInfo('Outdated avatar-database file found', 'TAvatarDatabase.Open');
+    // close and delete outdated file
+    DB.Free;
+    if (not Filename.DeleteFile()) then
+      raise ECoverDBException.Create('Could not delete ' + Filename.ToNative);
+    // reopen
+    DB := TSQLiteDatabase.Create(Filename.ToUTF8());
+    Version := 0;
   end;
+
+  // set version number after creation
+  if (Version = 0) then
+    SetVersion(AVATARDB_VERSION);
+
+  // speed-up disk-writing. The default FULL-synchronous mode is too slow.
+  // With this option disk-writing is approx. 4 times faster but the database
+  // might be corrupted if the OS crashes, although this is very unlikely.
+  DB.ExecSQL('PRAGMA synchronous = OFF;');
+
+  // the next line rather gives a slow-down instead of a speed-up, so we do not use it
+  //DB.ExecSQL('PRAGMA temp_store = MEMORY;');
+end;
+
+procedure TAvatarDatabase.InitAvatarDatabase();
+begin
+  DB.ExecSQL('CREATE TABLE IF NOT EXISTS ['+AVATAR_TBL+'] (' +
+               '[ID] INTEGER  NOT NULL PRIMARY KEY AUTOINCREMENT, ' +
+               '[Filename] TEXT  UNIQUE NOT NULL, ' +
+               '[Date] INTEGER  NOT NULL, ' +
+               '[Width] INTEGER  NOT NULL, ' +
+               '[Height] INTEGER  NOT NULL ' +
+             ')');
+
+  DB.ExecSQL('CREATE INDEX IF NOT EXISTS ['+AVATAR_IDX+'] ON ['+AVATAR_TBL+'](' +
+               '[Filename]  ASC' +
+             ')');
+
+  DB.ExecSQL('CREATE TABLE IF NOT EXISTS ['+AVATAR_THUMBNAIL_TBL+'] (' +
+               '[ID] INTEGER  NOT NULL PRIMARY KEY, ' +
+               '[Format] INTEGER  NOT NULL, ' +
+               '[Width] INTEGER  NOT NULL, ' +
+               '[Height] INTEGER  NOT NULL, ' +
+               '[Data] BLOB  NULL' +
+             ')');
+end;
+
+function TAvatarDatabase.FindAvatarIntern(const Filename: IPath): int64;
+begin
+  Result := DB.GetTableValue('SELECT [ID] FROM ['+AVATAR_TBL+'] ' +
+                             'WHERE [Filename] = ?',
+                             [Filename.ToUTF8]);
+end;
+
+function TAvatarDatabase.FindAvatar(const Filename: IPath): TAvatar;
+var
+  AvatarID: int64;
+begin
+  Result := nil;
+  try
+    AvatarID := FindAvatarIntern(Filename);
+    if (AvatarID > 0) then
+      Result := TAvatar.Create(AvatarID, Filename);
+  except on E: Exception do
+    Log.LogError(E.Message, 'TAvatarDatabase.FindAvatar');
+  end;
+end;
+
+function TAvatarDatabase.AvatarExists(const Filename: IPath): boolean;
+begin
+  Result := false;
+  try
+    Result := (FindAvatarIntern(Filename) > 0);
+  except on E: Exception do
+    Log.LogError(E.Message, 'TAvatarDatabase.CoverExists');
+  end;
+end;
+
+function TAvatarDatabase.AddAvatar(const Filename: IPath): TAvatar;
+var
+  AvatarID: int64;
+  Thumbnail: PSDL_Surface;
+  AvatarData: TBlobWrapper;
+  FileDate: TDateTime;
+  Info: TAvatarThumbnailInfo;
+begin
+  Result := nil;
+
+  //if (not FileExists(Filename)) then
+  //  Exit;
+
+  // TODO: replace '\' with '/' in filename
+  FileDate := Now(); //FileDateToDateTime(FileAge(Filename));
+
+  Thumbnail := CreateAvatarThumbnail(Filename, Info);
+  if (Thumbnail = nil) then
+    Exit;
+
+  AvatarData := TBlobWrapper.Create;
+  AvatarData.Write(Thumbnail^.pixels, Thumbnail^.h * Thumbnail^.pitch);
+
+  try
+    // Note: use a transaction to speed-up file-writing.
+    // Without data written by the first INSERT might be moved at the second INSERT.
+    DB.BeginTransaction();
+
+    // add general cover info
+    DB.ExecSQL('INSERT INTO ['+AVATAR_TBL+'] ' +
+               '([Filename], [Date], [Width], [Height]) VALUES' +
+               '(?, ?, ?, ?)',
+               [Filename.ToUTF8, DateTimeToUnixTime(FileDate),
+                Info.AvatarWidth, Info.AvatarHeight]);
+
+    // get auto-generated avatar ID
+    AvatarID := DB.GetLastInsertRowID();
+
+    // add thumbnail info
+    DB.ExecSQL('INSERT INTO ['+AVATAR_THUMBNAIL_TBL+'] ' +
+               '([ID], [Format], [Width], [Height], [Data]) VALUES' +
+               '(?, ?, ?, ?, ?)',
+               [AvatarID, Ord(Info.PixelFormat),
+                Thumbnail^.w, Thumbnail^.h, AvatarData]);
+
+    Result := TAvatar.Create(AvatarID, Filename);
+  except on E: Exception do
+    Log.LogError(E.Message, 'TAvatarDatabase.AddAvatar');
+  end;
+
+  DB.Commit();
+  AvatarData.Free;
+  SDL_FreeSurface(Thumbnail);
+end;
+
+function TAvatarDatabase.LoadAvatar(AvatarID: int64): TTexture;
+var
+  Width, Height: integer;
+  PixelFmt: TImagePixelFmt;
+  Data: PChar;
+  DataSize: integer;
+  Filename: IPath;
+  Table: TSQLiteUniTable;
+begin
+  Table := nil;
+
+  try
+    Table := DB.GetUniTable(Format(
+      'SELECT C.[Filename], T.[Format], T.[Width], T.[Height], T.[Data] ' +
+      'FROM ['+AVATAR_TBL+'] C ' +
+        'INNER JOIN ['+AVATAR_THUMBNAIL_TBL+'] T ' +
+        'USING(ID) ' +
+      'WHERE [ID] = %d', [AvatarID]));
+
+    Filename := Path(Table.FieldAsString(0));
+    PixelFmt := TImagePixelFmt(Table.FieldAsInteger(1));
+    Width    := Table.FieldAsInteger(2);
+    Height   := Table.FieldAsInteger(3);
+
+    Data := Table.FieldAsBlobPtr(4, DataSize);
+    if (Data <> nil) and
+       (PixelFmt = ipfRGB) then
+    begin
+      Result := Texture.CreateTexture(Data, Filename, Width, Height, 24)
+    end
+    else
+    begin
+      // FillChar() does not decrement the ref-count of ref-counted fields
+      // -> reset Name field manually
+      Result.Name := nil;
+      FillChar(Result, SizeOf(TTexture), 0);
+    end;
+  except on E: Exception do
+    Log.LogError(E.Message, 'TAvatarDatabase.LoadAvatar');
+  end;
+
+  Table.Free;
+end;
+
+procedure TAvatarDatabase.DeleteAvatar(AvatarID: int64);
+begin
+  DB.ExecSQL(Format('DELETE FROM ['+AVATAR_TBL+'] WHERE [ID] = %d', [AvatarID]));
+  DB.ExecSQL(Format('DELETE FROM ['+AVATAR_THUMBNAIL_TBL+'] WHERE [ID] = %d', [AvatarID]));
+end;
+
+(**
+ * Returns a pointer to an array of bytes containing the texture data in the
+ * requested size
+ *)
+function TAvatarDatabase.CreateAvatarThumbnail(const Filename: IPath; var Info: TAvatarThumbnailInfo): PSDL_Surface;
+var
+  //TargetAspect, SourceAspect: double;
+  //TargetWidth, TargetHeight: integer;
+  Thumbnail: PSDL_Surface;
+  MaxSize: integer;
+begin
+  Result := nil;
+
+  MaxSize := GetMaxAvatarSize();
+
+  Thumbnail := LoadImage(Filename);
+  if (not assigned(Thumbnail)) then
+  begin
+    Log.LogError('Could not load avatar: "'+ Filename.ToNative +'"', 'TAvatarDatabase.AddAvatar');
+    Exit;
+  end;
+
+  // Convert pixel format as needed
+  AdjustPixelFormat(Thumbnail, TEXTURE_TYPE_PLAIN);
+
+  Info.AvatarWidth  := Thumbnail^.w;
+  Info.AvatarHeight := Thumbnail^.h;
+  Info.PixelFormat := ipfRGB;
+
+  (* TODO: keep aspect ratio
+  TargetAspect := Width / Height;
+  SourceAspect := TexSurface.w / TexSurface.h;
+
+  // Scale texture to covers dimensions (keep aspect)
+  if (SourceAspect >= TargetAspect) then
+  begin
+    TargetWidth := Width;
+    TargetHeight := Trunc(Width / SourceAspect);
+  end
+  else
+  begin
+    TargetHeight := Height;
+    TargetWidth := Trunc(Height * SourceAspect);
+  end;
+  *)
+
+  // TODO: do not scale if image is smaller
+  ScaleImage(Thumbnail, MaxSize, MaxSize);
+
+  Result := Thumbnail;
+end;
+
+procedure TAvatarDatabase.LoadAvatars;
+var
+  Len:  Integer;
+  IterJPG, IterPNG: IFileIterator;
+  FileInfo: TFileInfo;
+begin
+  // first position for no-avatar
+  SetLength(AvatarsList, 1);
+
+  // jpg
+  IterJPG := FileSystem.FileFind(AvatarsPath.Append('*.jpg'), 0);
+
+  while (IterJPG.HasNext) do
+  begin
+    Len := Length(AvatarsList);
+    SetLength(AvatarsList, Len + 1);
+
+    FileInfo := IterJPG.Next;
+
+    AvatarsList[High(AvatarsList)] := AvatarsPath.Append(FileInfo.Name);
+  end;
+
+
+  // png
+  IterPNG := FileSystem.FileFind(AvatarsPath.Append('*.png'), 0);
+
+  while (IterPNG.HasNext) do
+  begin
+    Len := Length(AvatarsList);
+    SetLength(AvatarsList, Len + 1);
+
+    FileInfo := IterPNG.Next;
+
+    AvatarsList[High(AvatarsList)] := AvatarsPath.Append(FileInfo.Name);
+  end;
+  
 end;
 
 end.
+

--- a/src/base/UCommon.pas
+++ b/src/base/UCommon.pas
@@ -118,7 +118,6 @@ procedure FreeAlignedMem(P: pointer);
 function Equals(A, B: string; CaseSensitive: boolean = false): Boolean; overload;
 
 function GetArrayIndex(const SearchArray: array of UTF8String; Value: string; CaseInsensitiv: boolean = false): integer; overload;
-function GetArrayIndex(const SearchArray: array of string; Value: string; CaseInsensitiv: boolean = false): integer; overload;
 function GetArrayIndex(const SearchArray: array of integer; Value: integer): integer; overload;
 
 function ParseResolutionString(const ResolutionString: string; out x, y: integer): boolean;
@@ -633,11 +632,6 @@ begin
       Break;
     end;
   end;
-end;
-
-function GetArrayIndex(const SearchArray: array of string; Value: string; CaseInsensitiv: boolean = false): integer;
-begin
-  Result := GetArrayIndex(SearchArray, Value, CaseInsensitiv);
 end;
 
 (**

--- a/src/base/UIni.pas
+++ b/src/base/UIni.pas
@@ -74,6 +74,7 @@ const
   DEFAULT_RESOLUTION = '800x600';
   IMaxPlayerCount = 6;
   IPlayers: array[0..4] of UTF8String = ('1', '2', '3', '4', '6');
+  IPlayersVals: array[0..4] of integer = (1, 2, 3, 4, 6);
 
 type
 
@@ -101,13 +102,13 @@ type
       procedure LoadWebcamSettings(IniFile: TCustomIniFile);
     public
       // Players or Teams colors
-      SingColor:      array[0..(IMaxPlayerCount-1)] of integer; //FIXME remove this variable in all files
+      SingColor:      array[0..(IMaxPlayerCount-1)] of integer;
 
       Name: array[0..(IMaxPlayerCount-1)] of UTF8String;
       PlayerColor:    array[0..(IMaxPlayerCount-1)] of integer;
       TeamColor:      array[0..2] of integer;
 
-      PlayerAvatar:   array[0..(IMaxPlayerCount-1)] of string;
+      PlayerAvatar:   array[0..(IMaxPlayerCount-1)] of UTF8String;
       PlayerLevel:    array[0..(IMaxPlayerCount-1)] of integer;
 
       // Templates for Names Mod
@@ -229,19 +230,15 @@ type
       procedure Save();
       procedure SaveNames();
       procedure SaveLevel();
-      procedure SavePlayers(
-        TotalNumber: integer;
-        Names: array of UTF8String;
-        Colors: array of integer;
-        Levels: array of integer;
-        AvatarButtonsMd5: array of string;
-        Avatars: array of integer
-      );
+      procedure SavePlayerColors();
+      procedure SavePlayerAvatars();
+      procedure SavePlayerLevels();
       procedure SaveTeamColors();
       procedure SaveShowWebScore();
       procedure SaveJukeboxSongMenu();
       procedure SaveSoundFont(Name: string);
       procedure SaveWebcamSettings();
+      procedure SaveNumberOfPlayers();
       procedure SaveSingTimebarMode();
       procedure SaveJukeboxTimebarMode();
       procedure SaveJukeboxRepeatSongList();
@@ -846,10 +843,13 @@ begin
 
   for I := 0 to IMaxPlayerCount-1 do
   begin
+    // Name
     Name[I] := IniFile.ReadString('Name', 'P'+IntToStr(I+1), 'Player'+IntToStr(I+1));
+    // Color Player
     PlayerColor[I] := IniFile.ReadInteger('PlayerColor', 'P'+IntToStr(I+1), I + 1);
-    Self.SingColor[I] := Self.PlayerColor[I];
+    // Avatar Player
     PlayerAvatar[I] := IniFile.ReadString('PlayerAvatar', 'P'+IntToStr(I+1), '');
+    // Level Player
     PlayerLevel[I] := IniFile.ReadInteger('PlayerLevel', 'P'+IntToStr(I+1), 0);
   end;
 
@@ -1317,39 +1317,54 @@ begin
 end;
 
 
-procedure TIni.SavePlayers(
-  TotalNumber: integer;
-  Names: array of UTF8String;
-  Colors: array of integer;
-  Levels: array of integer;
-  AvatarButtonsMd5: array of string;
-  Avatars: array of integer
-);
+procedure TIni.SavePlayerColors;
+
 var
   IniFile: TIniFile;
-  I, J: integer;
-  PlayerNumber: string;
+  I: integer;
 begin
   if not Filename.IsReadOnly() then
   begin
-    Self.Players := TotalNumber;
     IniFile := TIniFile.Create(Filename.ToNative);
-    IniFile.WriteString('Game', 'Players', IPlayers[Players]);
+
+    //Colors for Names Mod
     for I := 1 to IMaxPlayerCount do
-    begin
-      J := I - 1;
-      Self.Name[J] := Names[J];
-      Self.PlayerAvatar[J] := AvatarButtonsMd5[Avatars[J]];
-      Self.PlayerColor[J] := Colors[J];
-      Self.PlayerLevel[J] := Levels[J];
-      Self.SingColor[J] := Colors[J];
-      PlayerNumber := 'P' + IntToStr(I);
-      IniFile.WriteString('Name', PlayerNumber, Self.Name[J]);
-      IniFile.WriteString('PlayerAvatar', PlayerNumber, Self.PlayerAvatar[J]);
-      IniFile.WriteString('PlayerColor', PlayerNumber, IntToStr(Self.PlayerColor[J]));
-      IniFile.WriteInteger('PlayerLevel', PlayerNumber, Levels[J]);
-    end;
-    IniFile.Free();
+      IniFile.WriteString('PlayerColor', 'P' + IntToStr(I), IntToStr(PlayerColor[I-1]));
+
+    IniFile.Free;
+  end;
+end;
+
+procedure TIni.SavePlayerAvatars;
+var
+  IniFile: TIniFile;
+  I: integer;
+begin
+  if not Filename.IsReadOnly() then
+  begin
+    IniFile := TIniFile.Create(Filename.ToNative);
+
+    //Colors for Names Mod
+    for I := 1 to IMaxPlayerCount do
+      IniFile.WriteString('PlayerAvatar', 'P' + IntToStr(I), PlayerAvatar[I-1]);
+
+    IniFile.Free;
+  end;
+end;
+
+procedure TIni.SavePlayerLevels;
+var
+  IniFile: TIniFile;
+  I: integer;
+begin
+  if not Filename.IsReadOnly() then
+  begin
+    IniFile := TIniFile.Create(Filename.ToNative);
+
+    for I := 1 to IMaxPlayerCount do
+      IniFile.WriteInteger('PlayerLevel', 'P' + IntToStr(I), PlayerLevel[I-1]);
+
+    IniFile.Free;
   end;
 end;
 
@@ -1399,6 +1414,21 @@ begin
     IniFile.Free;
   end;
 
+end;
+
+procedure TIni.SaveNumberOfPlayers;
+var
+  IniFile: TIniFile;
+begin
+  if not Filename.IsReadOnly() then
+  begin
+    IniFile := TIniFile.Create(Filename.ToNative);
+
+    // Players
+    IniFile.WriteString('Game', 'Players', IPlayers[Players]);
+
+    IniFile.Free;
+  end;
 end;
 
 procedure TIni.SaveSingTimebarMode;

--- a/src/base/UMain.pas
+++ b/src/base/UMain.pas
@@ -175,9 +175,14 @@ begin
     USongs.CatSongs := TCatSongs.Create();
     USongs.Songs := TSongs.Create(); //in a new thread
 
+    // Theme
     UThemes.Theme.LoadTheme(Ini.Theme, Ini.Color);
+
+    //avatars cache
+    UAvatars.Avatars := TAvatarDatabase.Create();
+
+    // Graphics
     UGraphic.Initialize3D(WindowTitle);
-    UAvatars.SetAvatarsList();
 
     UMusic.InitializeSound();
     UMusic.InitializeVideo();

--- a/src/base/UMusic.pas
+++ b/src/base/UMusic.pas
@@ -486,6 +486,7 @@ type
       function  Length: real;
 
       function Open(const Filename: IPath): boolean; // true if succeed
+      function OpenWithInstrum(const Filename: IPath; const InstrumFilename: IPath): boolean; // true if succeed
       procedure Close;
 
       procedure Play;

--- a/src/base/USong.pas
+++ b/src/base/USong.pas
@@ -101,6 +101,7 @@ type
     // filenames
     Cover:      IPath;
     Mp3:        IPath;
+    Instrum:    IPath;
     Background: IPath;
     Video:      IPath;
 
@@ -215,6 +216,7 @@ begin
   Self.FileName := PATH_NONE();
   Self.Cover    := PATH_NONE();
   Self.Mp3      := PATH_NONE();
+  Self.Instrum  := PATH_NONE();
   Self.Background:= PATH_NONE();
   Self.Video    := PATH_NONE();
 end;
@@ -277,12 +279,13 @@ begin
   Self.Year := 0;
   if (not FileSystem.FileAge(aFileName, Self.FileDate)) then
     Self.FileDate := 0;
-  
+
   // set to default encoding
   Self.Encoding := Ini.DefaultEncoding;
 
   //Required Information
   Self.Mp3 := PATH_NONE;
+  Self.Instrum := PATH_NONE;
   Self.BPM := 0;
   Self.GAP := 0;
   Self.Start := 0;
@@ -671,6 +674,14 @@ begin
           end
           else
             Log.LogError('Can''t find audio file in song: '+Self.FullPath);
+        end;
+        'INSTRUM': //sound source file
+        begin
+          EncFile := DecodeFilename(Value);
+          if (Self.Path.Append(EncFile).IsFile()) then
+          begin
+            Self.Instrum := EncFile;
+          end
         end;
         'BPM': //beats per minute
         begin

--- a/src/media/UAudioPlaybackBase.pas
+++ b/src/media/UAudioPlaybackBase.pas
@@ -1,8 +1,8 @@
 {*
     UltraStar WorldParty - Karaoke Game
-	
-	UltraStar WorldParty is the legal property of its developers, 
-	whose names	are too numerous to list here. Please refer to the 
+
+	UltraStar WorldParty is the legal property of its developers,
+	whose names	are too numerous to list here. Please refer to the
 	COPYRIGHT file distributed with this source distribution.
 
     This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program. Check "LICENSE" file. If not, see 
+    along with this program. Check "LICENSE" file. If not, see
 	<http://www.gnu.org/licenses/>.
  *}
 
@@ -61,6 +61,7 @@ type
       function GetName: string; virtual; abstract;
 
       function Open(const Filename: IPath): boolean; // true if succeed
+      function OpenWithInstrum(const Filename: IPath; const InstrumFilename: IPath): boolean; // true if succeed
       procedure Close;
 
       procedure Play;
@@ -164,6 +165,33 @@ begin
   end;
 
   if doVoiceRemoval then MusicStream.AddSoundEffect(TVoiceRemoval.Create());
+  if assigned(IReplayGain) and IReplayGain.CanEnable then MusicStream.AddSoundFX(IReplayGain.Create());
+
+  Result := true;
+end;
+
+function TAudioPlaybackBase.OpenWithInstrum(const Filename: IPath; const InstrumFilename: IPath): boolean;
+var
+  customInstrum: boolean;
+begin
+  // free old MusicStream
+  MusicStream.Free;
+
+  customInstrum := doVoiceRemoval and InstrumFilename.IsSet();
+  if customInstrum then
+	MusicStream := OpenStream(InstrumFilename);
+  if not customInstrum or not assigned(MusicStream) then
+  begin
+	MusicStream := OpenStream(Filename);
+	customInstrum := false;
+  end;
+  if not assigned(MusicStream) then
+  begin
+    Result := false;
+    Exit;
+  end;
+
+  if doVoiceRemoval and not customInstrum then MusicStream.AddSoundEffect(TVoiceRemoval.Create());
   if assigned(IReplayGain) and IReplayGain.CanEnable then MusicStream.AddSoundFX(IReplayGain.Create());
 
   Result := true;

--- a/src/screens/UScreenPartyPlayer.pas
+++ b/src/screens/UScreenPartyPlayer.pas
@@ -168,7 +168,13 @@ begin
       Party.AddPlayer(I, Button[I * 5 + 1 + J].Text[0].Text);
 
     // no avatar on Party
-    UAvatars.GetAvatarsList().LoadConfig(true);
+    AvatarPlayerTextures[I + 1] := NoAvatarTexture[I + 1];
+
+    Col := GetPlayerColor(Num[I]);
+
+    AvatarPlayerTextures[I + 1].ColR := Col.R;
+    AvatarPlayerTextures[I + 1].ColG := Col.G;
+    AvatarPlayerTextures[I + 1].ColB := Col.B;
   end;
 
 

--- a/src/screens/UScreenPlayerSelector.pas
+++ b/src/screens/UScreenPlayerSelector.pas
@@ -25,7 +25,9 @@ unit UScreenPlayerSelector;
 
 interface
 
-{$MODE OBJFPC}
+{$IFDEF FPC}
+  {$MODE Delphi}
+{$ENDIF}
 
 {$I switches.inc}
 
@@ -33,6 +35,7 @@ uses
   dglOpenGL,
   SysUtils,
   sdl2,
+  UAvatars,
   UDisplay,
   UFiles,
   md5,
@@ -81,7 +84,7 @@ type
       APlayerColor: array of integer;
 
       PlayerAvatarButton: array of integer;
-      PlayerAvatarButtonMD5: array of string;
+      PlayerAvatarButtonMD5: array of UTF8String;
     public
       OpenedInOptions: boolean;
 
@@ -90,6 +93,7 @@ type
       function ParseMouse(MouseButton: integer; BtnDown: boolean; X, Y: integer): boolean; override;
 
       procedure OnShow; override;
+      procedure OnHide; override;
       function Draw: boolean; override;
 
       procedure SetAnimationProgress(Progress: real); override;
@@ -97,7 +101,7 @@ type
       procedure SkipTo(Target: cardinal);
 
       procedure PlayerColorButton(K: integer);
-      function NoRepeatColors(ColorP: integer; CurrentInteraction: integer; Pos: integer):integer;
+      function NoRepeatColors(ColorP: integer; Interaction: integer; Pos: integer):integer;
       procedure RefreshPlayers();
       procedure RefreshProfile();
       procedure RefreshColor();
@@ -114,9 +118,7 @@ const
 implementation
 
 uses
-  Classes,
   Math,
-  UAvatars,
   UCommon,
   UGraphic,
   ULanguage,
@@ -197,7 +199,7 @@ begin
             Randomize();
             PrevAvatar := Self.Interaction;
             repeat
-              CurrentAvatar := Random(Length(Self.PlayerAvatarButton));
+              CurrentAvatar := Random(Length(UAvatars.AvatarsList));
             until (CurrentAvatar <> PrevAvatar) and (CurrentAvatar <> 0);
             Self.SkipTo(CurrentAvatar);
           end;
@@ -235,8 +237,6 @@ begin
           if not Self.SingButtonPressed then
             Exit();
 
-          UIni.Ini.SavePlayers(Self.CountIndex, Self.PlayerNames, Self.Num, Self.PlayerLevel, Self.PlayerAvatarButtonMD5, Self.PlayerAvatars);
-          UAvatars.GetAvatarsList().LoadConfig();
           if Self.SelInteraction in [6, 7] then
             if Self.OpenedInOptions then
               Self.FadeTo(@UGraphic.ScreenOptions, UMusic.SoundLib.Back)
@@ -265,7 +265,7 @@ begin
 
           if (Interaction = 1) then // Player selection
             begin //TODO: adapt this to new playersize
-              if Self.PlayerIndex < StrToInt(UIni.IPlayers[Self.CountIndex]) - 1 then
+              if (PlayerIndex < UIni.IPlayersVals[CountIndex]-1) then
             begin
               PlayerIndex := PlayerIndex + 1;
 
@@ -297,7 +297,7 @@ begin
           end;
 
           if (Interaction = 5) then  //avatar selection
-            Self.SkipTo(IfThen(Self.AvatarTarget + 1 >= Length(Self.PlayerAvatarButton), 0, Round(Self.AvatarTarget) + 1));
+            Self.SkipTo(IfThen(Self.AvatarTarget + 1 >= Length(UAvatars.AvatarsList), 0, Round(Self.AvatarTarget) + 1));
 
         end;
       SDLK_LEFT:
@@ -341,7 +341,7 @@ begin
 
 
           if (Interaction = 5) then
-            Self.SkipTo(IfThen(Self.AvatarTarget - 1 < 0, Length(Self.PlayerAvatarButton) - 1, Round(Self.AvatarTarget) - 1));
+            Self.SkipTo(IfThen(Self.AvatarTarget - 1 < 0, Length(UAvatars.AvatarsList) - 1, Round(Self.AvatarTarget) - 1));
 
         end;
 
@@ -352,29 +352,57 @@ end;
 procedure TScreenPlayerSelector.GenerateAvatars();
 var
   I: integer;
-  Avatar: UAvatars.TAvatar;
-  Avatars: TFPList;
-  AvatarsList: UAvatars.TAvatarList;
+  AvatarTexture: TTexture;
+  Avatar: TAvatar;
+  AvatarFile: IPath;
+  Hash: string;
 begin
-  AvatarsList := UAvatars.GetAvatarsList();
-  Avatars := AvatarsList.GetAvatars();
-  SetLength(Self.PlayerAvatarButton, Avatars.Count + 1);
-  SetLength(Self.PlayerAvatarButtonMD5, Avatars.Count + 1);
-  Self.PlayerAvatarButton[0] := Self.AddButton(UThemes.Theme.PlayerSelector.PlayerAvatar);
-  Self.Button[Self.PlayerAvatarButton[0]].Texture := AvatarsList.GetPlayersNo()[1];
-  Self.Button[Self.PlayerAvatarButton[0]].Selectable := false;
-  Self.Button[Self.PlayerAvatarButton[0]].Selected := false;
-  Self.Button[Self.PlayerAvatarButton[0]].Visible := false;
-  for I := 1 to Avatars.Count do
+
+  SetLength(PlayerAvatarButton, Length(AvatarsList) + 1);
+  SetLength(PlayerAvatarButtonMD5, Length(AvatarsList) + 1);
+
+  // 1st no-avatar dummy
+  for I := 1 to UIni.IMaxPlayerCount do
   begin
-    Avatar := TAvatar(Avatars[I - 1]);
-    Self.PlayerAvatarButton[I] := Self.AddButton(UThemes.Theme.PlayerSelector.PlayerAvatar);
-    Self.PlayerAvatarButtonMD5[I] := Avatar.MD5;
-    Self.Button[Self.PlayerAvatarButton[I]].Texture := Avatar.Texture;
-    Self.Button[Self.PlayerAvatarButton[I]].Selectable := false;
-    Self.Button[Self.PlayerAvatarButton[I]].Selected := false;
-    Self.Button[Self.PlayerAvatarButton[I]].Visible := false;
+    NoAvatarTexture[I] := Texture.LoadTexture(Skin.GetTextureFileName('NoAvatar_P' + IntToStr(I)), TEXTURE_TYPE_TRANSPARENT, $FFFFFF);
   end;
+
+  // create no-avatar
+  Self.PlayerAvatarButton[0] := Self.AddButton(UThemes.Theme.PlayerSelector.PlayerAvatar);
+  Button[PlayerAvatarButton[0]].Texture := NoAvatarTexture[1];
+  Button[PlayerAvatarButton[0]].Selectable := false;
+  Button[PlayerAvatarButton[0]].Selected := false;
+  Button[PlayerAvatarButton[0]].Visible := false;
+
+  // create avatars buttons
+  for I := 1 to High(AvatarsList) do
+  begin
+    // create avatar
+    Self.PlayerAvatarButton[I] := Self.AddButton(UThemes.Theme.PlayerSelector.PlayerAvatar);
+
+    AvatarFile := AvatarsList[I];
+
+    Hash := MD5Print(MD5File(AvatarFile.ToNative));
+    PlayerAvatarButtonMD5[I] := UpperCase(Hash);
+
+    // load avatar and cache its texture
+    Avatar := Avatars.FindAvatar(AvatarFile);
+    if (Avatar = nil) then
+      Avatar := Avatars.AddAvatar(AvatarFile);
+
+    if (Avatar <> nil) then
+    begin
+      AvatarTexture := Avatar.GetTexture();
+      Button[PlayerAvatarButton[I]].Texture := AvatarTexture;
+
+      Button[PlayerAvatarButton[I]].Selectable := false;
+      Button[PlayerAvatarButton[I]].Selected := false;
+      Button[PlayerAvatarButton[I]].Visible := false;
+    end;
+
+    Avatar.Free;
+  end;
+
 end;
 
 procedure TScreenPlayerSelector.ChangeSelectPlayerPosition(Player: integer);
@@ -389,7 +417,7 @@ var
   DesCol: TRGB;
 begin
 
-  Count := StrToInt(UIni.IPlayers[Self.CountIndex]);
+  Count := UIni.IPlayersVals[CountIndex];
 
   while (PlayerIndex > Count-1) do
     PlayerIndex := PlayerIndex - 1;
@@ -437,13 +465,13 @@ var
   Used: boolean;
 begin
   // no-avatar for current player
-  Self.Button[Self.PlayerAvatarButton[0]].Texture.TexNum := UAvatars.GetAvatarsList().GetPlayersNo()[PlayerIndex + 1].TexNum;
+  Button[PlayerAvatarButton[0]].Texture.TexNum := NoAvatarTexture[PlayerIndex + 1].TexNum;
 
   Button[PlayerName].Text[0].Text := PlayerNames[PlayerIndex];
 
   SelectsS[PlayerSelectLevel].SetSelectOpt(PlayerLevel[PlayerIndex]);
 
-  Count := StrToInt(UIni.IPlayers[Self.CountIndex]);
+  Count := UIni.IPlayersVals[CountIndex];
 
   ChangeSelectPlayerPosition(PlayerIndex);
   Self.Text[2].Text := ULanguage.Language.Translate('SING_PLAYER_EDIT')+': '+ULanguage.Language.Translate('OPTION_PLAYER_'+IntToStr(Self.PlayerIndex + 1));
@@ -497,22 +525,22 @@ begin
 
 end;
 
-function TScreenPlayerSelector.NoRepeatColors(ColorP:integer; CurrentInteraction:integer; Pos:integer):integer;
+function TScreenPlayerSelector.NoRepeatColors(ColorP:integer; Interaction:integer; Pos:integer):integer;
 var
   Z, Count:integer;
 begin
-  Count := StrToInt(UIni.IPlayers[Self.CountIndex]);
+  Count := UIni.IPlayersVals[CountIndex];
 
   if (ColorP > Length(PlayerColors)) then
-    ColorP := NoRepeatColors(1, CurrentInteraction, Pos);
+    ColorP := NoRepeatColors(1, Interaction, Pos);
 
   if (ColorP <= 0) then
-    ColorP := NoRepeatColors(High(PlayerColors), CurrentInteraction, Pos);
+    ColorP := NoRepeatColors(High(PlayerColors), Interaction, Pos);
 
   for Z := Count -1 downto 0 do
   begin
-    if (Num[Z] = ColorP) and (Z <> CurrentInteraction) then
-      ColorP := NoRepeatColors(ColorP + Pos, CurrentInteraction, Pos)
+    if (Num[Z] = ColorP) and (Z <> Interaction) then
+      ColorP := NoRepeatColors(ColorP + Pos, Interaction, Pos)
   end;
 
   Result := ColorP;
@@ -625,7 +653,7 @@ var
 begin
   if (PlayerAvatars[Player] = 0) then
   begin
-    Statics[PlayerCurrentAvatar[Player]].Texture := UAvatars.GetAvatarsList().GetPlayersNo()[Player + 1];
+    Statics[PlayerCurrentAvatar[Player]].Texture := NoAvatarTexture[Player + 1];
 
     Col := GetPlayerColor(Num[Player]);
 
@@ -687,6 +715,46 @@ begin
   Interaction := 0;
 end;
 
+procedure TScreenPlayerSelector.OnHide();
+var
+  Col: TRGB;
+  I: integer;
+begin
+  inherited;
+  UIni.Ini.Players := Self.CountIndex;
+  UNote.PlayersPlay := UIni.IPlayersVals[Self.CountIndex];
+  for I := 1 to UIni.IPlayersVals[Self.CountIndex] do
+  begin
+    UIni.Ini.Name[I - 1] := Self.PlayerNames[I - 1];
+    UIni.Ini.PlayerColor[I - 1] := Self.Num[I - 1];
+    UIni.Ini.SingColor[I - 1] := Self.Num[I - 1];
+    UIni.Ini.PlayerLevel[I - 1] := Self.PlayerLevel[I - 1];
+    UIni.Ini.PlayerAvatar[I - 1] := Self.PlayerAvatarButtonMD5[Self.PlayerAvatars[I - 1]];
+    if Self.PlayerAvatars[I - 1] = 0 then
+    begin
+      UAvatars.AvatarPlayerTextures[I] := UAvatars.NoAvatartexture[I];
+      Col := UThemes.GetPlayerColor(Self.Num[I - 1]);
+      UAvatars.AvatarPlayerTextures[I].ColR := Col.R;
+      UAvatars.AvatarPlayerTextures[I].ColG := Col.G;
+      UAvatars.AvatarPlayerTextures[I].ColB := Col.B;
+    end
+    else
+    begin
+      Self.Button[Self.PlayerAvatarButton[Self.PlayerAvatars[I-1]]].Texture.Int := 1;
+      UAvatars.AvatarPlayerTextures[I] := Self.Button[Self.PlayerAvatarButton[Self.PlayerAvatars[I-1]]].Texture;
+    end;
+  end;
+  UIni.Ini.SaveNumberOfPlayers();
+  UIni.Ini.SaveNames();
+  UIni.Ini.SavePlayerColors();
+  UIni.Ini.SavePlayerAvatars();
+  UIni.Ini.SavePlayerLevels();
+  UThemes.LoadPlayersColors();
+  UThemes.Theme.ThemeScoreLoad();
+  UGraphic.ScreenScore := UScreenScore.TScreenScore.Create();
+  UGraphic.ScreenSing := UScreenSingController.TScreenSingController.Create();
+end;
+
 procedure TScreenPlayerSelector.SetAvatarScroll;
 var
   B:        integer;
@@ -698,7 +766,7 @@ var
   Factor:   real;
 begin
 
-  VS := UAvatars.GetAvatarsList().GetAvatars().Count;
+  VS := Length(AvatarsList);
 
   case NumVisibleAvatars of
     3: Factor := 1;
@@ -707,7 +775,7 @@ begin
    end;
 
   // Update positions of all avatars
-  for B := PlayerAvatarButton[0] to PlayerAvatarButton[VS] do
+  for B := PlayerAvatarButton[0] to PlayerAvatarButton[High(AvatarsList)] do
   begin
     Button[B].Visible := true; // adjust visibility
 
@@ -754,10 +822,10 @@ end;
 procedure TScreenPlayerSelector.SkipTo(Target: cardinal);
 begin
   Self.IsScrolling := true;
-  if (Target = 0) and (Self.AvatarTarget = Length(Self.PlayerAvatarButton) - 1) then //go to initial song if reach the end of subselection list
+  if (Target = 0) and (Self.AvatarTarget = Length(UAvatars.AvatarsList) - 1) then //go to initial song if reach the end of subselection list
     Self.AvatarCurrent := -1
-  else if (Target = Length(Self.PlayerAvatarButton) - 1) and (Self.AvatarTarget = 0) then //go to final song if reach the start of subselection list
-    Self.AvatarCurrent := Length(Self.PlayerAvatarButton);
+  else if (Target = Length(UAvatars.AvatarsList) - 1) and (Self.AvatarTarget = 0) then //go to final song if reach the start of subselection list
+    Self.AvatarCurrent := Length(UAvatars.AvatarsList);
 
   Self.AvatarTarget := Target;
   Self.PlayerAvatars[Self.PlayerIndex] := Self.AvatarTarget;
@@ -787,7 +855,7 @@ begin
 
     AvatarCurrent := AvatarCurrent + dx*dt;
 
-    if SameValue(AvatarCurrent, AvatarTarget, 0.002) and (UAvatars.GetAvatarsList().GetAvatars().Count > 0) then
+    if SameValue(AvatarCurrent, AvatarTarget, 0.002) and (Length(AvatarsList) > 0) then
     begin
       isScrolling := false;
       AvatarCurrent := AvatarTarget;

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -798,7 +798,6 @@ var
   R, G, B: real;
   Col2: integer;
   ArrayStartModifier: integer;
-  AvatarPlayerTextures: UAvatars.TAvatarPlayerTextures;
 begin
   inherited Create;
 
@@ -903,7 +902,7 @@ begin
     else
       ArrayStartModifier := 0; //this should never happen
   end;
-  AvatarPlayerTextures := UAvatars.GetAvatarsList().GetPlayers();
+
   for I := 1 to PlayersPlay do
   begin
     if((Screens = 2) and (PlayersPlay > 3) and (I > Trunc(PlayersPlay/2))) then

--- a/src/screens/UScreenScore.pas
+++ b/src/screens/UScreenScore.pas
@@ -841,7 +841,7 @@ begin
     StaticLevel[Player]          := AddStatic(Theme.Score.StaticLevel[Player]);
     StaticLevelRound[Player]     := AddStatic(Theme.Score.StaticLevelRound[Player]);
 
-    AddButton(Theme.Score.ButtonContinue); 
+    AddButton(Theme.Score.ButtonContinue);
 
     // ######################
     // Score screen textures
@@ -1807,7 +1807,7 @@ begin
     begin
       AudioPlayback.Close;
 
-      if AudioPlayback.Open(CatSongs.Song[select].Path.Append(CatSongs.Song[select].Mp3)) then
+      if AudioPlayback.OpenWithInstrum(CatSongs.Song[select].Path.Append(CatSongs.Song[select].Mp3),CatSongs.Song[select].Path.Append(CatSongs.Song[select].Instrum)) then
       begin
         if (CatSongs.Song[select].PreviewStart > 0) then
           AudioPlayback.Position := CatSongs.Song[select].PreviewStart

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -1640,7 +1640,7 @@ begin
   Song := CatSongs.Song[Interaction];
 
   PlayMidi := false;
-  if Song.Mp3.IsSet() and AudioPlayback.Open(Song.Path.Append(Song.Mp3)) then
+  if Song.Mp3.IsSet() and AudioPlayback.OpenWithInstrum(Song.Path.Append(Song.Mp3),Song.Path.Append(Song.Instrum)) then
   begin
     PreviewOpened := Interaction;
 

--- a/src/screens/UScreenSong.pas
+++ b/src/screens/UScreenSong.pas
@@ -1367,13 +1367,46 @@ end;
 
 procedure TScreenSong.OnShow();
 var
-  I: integer;
+  Avatar: TAvatar;
+  Col: TRGB;
+  I, J: integer;
   Visible: boolean;
 begin
   inherited;
   if not Assigned(UGraphic.ScreenSongMenu) then //load the screens only the first time
   begin
-    UNote.PlayersPlay:= StrToInt(UIni.IPlayers[UIni.Ini.Players]); //FIXME set this variable is needed to see avatars in scores screen!
+    //TODO move avatar load to UAvatar
+    UIni.Ini.SingColor := UIni.Ini.PlayerColor; //FIXME remove this variable in all files
+    UNote.PlayersPlay:= UIni.IPlayersVals[UIni.Ini.Players]; //FIXME set this variable is needed to see avatars in scores screen!
+    J := 1;
+    for I := 1 to High(AvatarsList) do
+      if GetArrayIndex(UIni.Ini.PlayerAvatar, UpperCase(MD5Print(MD5File(AvatarsList[I].ToNative())))) <> -1 then
+      begin
+        Avatar := Avatars.FindAvatar(AvatarsList[I]);
+        if (Avatar <> nil) then
+          UAvatars.AvatarPlayerTextures[J] := Avatar.GetTexture()
+        else
+        begin
+          UAvatars.AvatarPlayerTextures[J] := UTexture.Texture.LoadTexture(Skin.GetTextureFileName('NoAvatar_P'+IntToStr(J)), TEXTURE_TYPE_TRANSPARENT, $FFFFFF);
+          Col := UThemes.GetPlayerColor(UIni.Ini.PlayerColor[J]);
+          UAvatars.AvatarPlayerTextures[J].ColR := Col.R;
+          UAvatars.AvatarPlayerTextures[J].ColG := Col.G;
+          UAvatars.AvatarPlayerTextures[J].ColB := Col.B;
+        end;
+        FreeAndNil(Avatar);
+        Inc(J);
+      end;
+
+    for I := J to UIni.IPlayersVals[UIni.Ini.Players] do
+    begin
+        UAvatars.AvatarPlayerTextures[I] := UTexture.Texture.LoadTexture(Skin.GetTextureFileName('NoAvatar_P'+IntToStr(J)), TEXTURE_TYPE_TRANSPARENT, $FFFFFF);
+        Col := UThemes.GetPlayerColor(UIni.Ini.PlayerColor[I - 1]);
+        UAvatars.AvatarPlayerTextures[I].ColR := Col.R;
+        UAvatars.AvatarPlayerTextures[I].ColG := Col.G;
+        UAvatars.AvatarPlayerTextures[I].ColB := Col.B;
+    end;
+    UThemes.LoadPlayersColors();
+    UThemes.Theme.ThemeScoreLoad();
     UGraphic.ScreenScore := UScreenScore.TScreenScore.Create();
     UGraphic.ScreenSing := UScreenSingController.TScreenSingController.Create();
     UGraphic.ScreenSongMenu := UScreenSongMenu.TScreenSongMenu.Create();

--- a/src/screens/controllers/UScreenSingController.pas
+++ b/src/screens/controllers/UScreenSingController.pas
@@ -736,7 +736,7 @@ begin
   PlayMidi := false;
   MidiFadeIn := false;
 
-  AudioPlayback.Open(CurrentSong.Path.Append(CurrentSong.Mp3));
+  AudioPlayback.OpenWithInstrum(CurrentSong.Path.Append(CurrentSong.Mp3),CurrentSong.Path.Append(CurrentSong.Instrum));
   if ScreenSong.Mode = smMedley then
     AudioPlayback.SetVolume(0.1)
   else

--- a/src/screens/views/UScreenSingView.pas
+++ b/src/screens/views/UScreenSingView.pas
@@ -488,7 +488,6 @@ var
   Col: array [1..UIni.IMaxPlayerCount] of TRGB;
   I: integer;
   Color: cardinal;
-  AvatarPlayerTextures: UAvatars.TAvatarPlayerTextures;
 begin
   lastVolume:= -1;
   //too dangerous, a mouse button is quickly pressed by accident
@@ -864,7 +863,6 @@ begin
   ScreenSing.InfoMessageText := ScreenSing.AddText(Theme.Sing.InfoMessageText);
 
   // avatars
-  AvatarPlayerTextures := UAvatars.GetAvatarsList().GetPlayers();
   StaticP1Avatar[0] := ScreenSing.AddStatic(Theme.Sing.StaticP1Avatar);
   ScreenSing.Statics[StaticP1Avatar[0]].Texture := AvatarPlayerTextures[1];
   ScreenSing.Statics[StaticP1Avatar[0]].Texture.X  := Theme.Sing.StaticP1Avatar.X;


### PR DESCRIPTION
Buenas.
Hace un par de meses [pregunté por el foro](https://ultrastar-es.org/foro/viewtopic.php?t=14061) sobre esta función que me había animado a añadir al juego: la posibilidad de añadir instrumentales a las canciones.
Sé que me dijisteis que en principio esta función estaba descartada y que no se iba a añadir, y en parte por eso y en parte porque he estado ocupado es por lo que he tardado tanto en hacer esta pull request.

No obstante, os la comparto igualmente porque a mí me parece una función muy útil para el programa independientemente de la web, y de que ponerse a actualizar todas las canciones existentes para añadir esta función sería imposible.
Es una función que puede simplemente estar ahí en el programa y, en adelante, quien quiera que la use, y quien no le va a funcionar el programa exactamente igual que hacía anteriormente. Por eso os la propongo, esta vez con el código en la mano.

Yo ya la tengo añadida en un par de canciones que o bien he hecho yo en el Yass o he descargado de la web y retocado añadiendo esto, y me funciona muy bien, y la mejora respecto al filtro en algunas canciones es tremenda.

Os dejo aquí la descripción traducida (y bien formateada) de la commit en mi fork, donde explico brevemente cómo funcionaría:
> Añadido parámetro opcional #INSTRUM a los archivos de las canciones.
> 
> Permite especificar un archivo de audio adicional para la variación instrumental de la canción, que sería reproducido cuando se pulsase la tecla F7 en lugar del archivo de #MP3 con el filtro de voz aplicado.
> Esto permite un karaoke sin voces de mucha mayor calidad en las canciones en las que es fácil encontrar la variación instrumental (como en muchas de las bandas sonoras de películas modernas).
> 
> Si el parámetro no se encuentra en el archivo de la canción, la tecla F7 simplemente activa el filtro como ha hecho siempre (no cambia nada respecto a lo anterior).
> Sólo si el parámetro está en el archivo y apunta a un archivo de audio válido, se reproducirá ese archivo en lugar de activar el filtro sobre el archivo del #MP3.
> Añadir este parámetro a un archivo de canción no rompe tampoco versiones antiguas del programa porque el parámetro simplemente se ignora.

Os animo a revisarlo y a añadir la función, ya que, insisto, que la función exista en el programa no implica que haya que actualizar las canciones ya existentes, ni siquiera que haya que actualizar la web si no es compatible con el proceso de subida de canciones (que no conozco porque no soy creador, no tengo tiempo más que para hacer muy de vez en cuando un par de canciones que me apetecen mucho y no están en la web).

En resumen, es una función que no estorba, y puede sumar (para mí, ya suma, y para otros puede en un futuro).
Espero que os animéis a añadirla.

Gracias en cualquier caso por el maravilloso programa que nos ofrecéis.
¡Un saludo!

(P.S.: Los cambios que son eliminar espacios en blanco al final de la línea han sido cosa del editor, los acabo de ver.)